### PR TITLE
fixed the double issue

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="argouml-diagrams-structure" />
+        <module name="argouml-mdr" />
+        <module name="argouml-transformer" />
+        <module name="argouml-euml" />
+        <module name="argouml-diagrams-deployment" />
+        <module name="argouml-diagrams-activity" />
+        <module name="argouml-umlpropertypanels" />
+        <module name="argouml-diagrams-class" />
+        <module name="argouml-diagrams-sequence" />
+        <module name="argouml-diagrams-state" />
+        <module name="argouml-model" />
+        <module name="argouml-build" />
+        <module name="argouml-notation" />
+        <module name="argouml" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-app/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-build/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-diagrams-activity2/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-diagrams-class2/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-diagrams-deployment2/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-diagrams-sequence2/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-diagrams-state2/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-diagrams-structure2/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-model-euml/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-model-mdr/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-model/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-notation/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-transformer/src" charset="ISO-8859-1" />
+    <file url="file://$PROJECT_DIR$/src/argouml-core-umlpropertypanels/src" charset="ISO-8859-1" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="sonatype-nexus-snapshots" />
+      <option name="name" value="Sonatype Nexus Snapshots" />
+      <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="argouml" />
+      <option name="name" value="ArgoUML-Provided Parts Repository (from Tigris)" />
+      <option name="url" value="https://argouml-tigris-org.github.io/tigris/maven2" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/argouml-app/src/org/argouml/uml/diagram/state/ui/FigStateVertex.java
+++ b/src/argouml-app/src/org/argouml/uml/diagram/state/ui/FigStateVertex.java
@@ -182,7 +182,7 @@ public abstract class FigStateVertex extends FigNodeModelElement {
         List<Point> ret = new ArrayList<Point>();
         int cx = getBigPort().getCenter().x;
         int cy = getBigPort().getCenter().y;
-        double radius = getBigPort().getWidth() / 2 + 1;
+        double radius = getBigPort().getWidth() / 2.0 + 1;
         final double pi2 = Math.PI * 2;
         for (int i = 0; i < CIRCLE_POINTS; i++) {
             int x = (int) (cx + Math.cos(pi2 * i / CIRCLE_POINTS) * radius);


### PR DESCRIPTION
Describe the technical debt
For one operand in the addition operation, cast it to double to prevent issues.

Expected behavior
When an integer and a double are combined without proper casting, it can lead to incorrect results. Casting the integer to a double prevents such issues and ensures accurate calculations.

[Screenshots]

This is the screenshot :

![image](https://github.com/user-attachments/assets/63cfabf2-9850-4636-9dfe-5eaa55686a35)

Additional context
File: FigStateVertex.java
Path: src\argouml-app\src\org\argouml\uml\diagram\state\ui