### PR TITLE
Refactor duplicated event handling logic in TabConstraints.java

### DIFF
--- a/src/argouml-app/src/org/argouml/uml/ui/TabConstraints.java
+++ b/src/argouml-app/src/org/argouml/uml/ui/TabConstraints.java
@@ -699,61 +699,48 @@ public class TabConstraints extends AbstractArgoJPanel
         }
 
         protected void fireConstraintDataChanged(
-                         int nIdx,
-                         Object mcOld,
-                         Object mcNew) {
-            // Guaranteed to return a non-null array
-            Object[] listeners = theMEllListeners.getListenerList();
+        int nIdx,
+        Object mcOld,
+        Object mcNew) {
 
-            ConstraintChangeEvent cce = null;
-
-            // Process the listeners last to first, notifying
-            // those that are interested in this event
-            for (int i = listeners.length - 2; i >= 0; i -= 2) {
-                if (listeners[i] == ConstraintChangeListener.class) {
-                    // Lazily create the event:
-                    if (cce == null) {
-                        cce = new ConstraintChangeEvent(
-                            this,
-                            nIdx,
-                            new CR(mcOld, nIdx),
-                            new CR(mcNew, nIdx));
-                    }
-
-                    ((ConstraintChangeListener) listeners[i + 1])
-                        .constraintDataChanged(cce);
-                }
-            }
-        }
+    fireConstraintEvent(nIdx, mcOld, mcNew, true);
+}
 
         protected void fireConstraintNameChanged(
-                         int nIdx,
-                         Object mcOld,
-                         Object mcNew) {
-            // Guaranteed to return a non-null array
-            Object[] listeners = theMEllListeners.getListenerList();
+        int nIdx,
+        Object mcOld,
+        Object mcNew) {
 
-            ConstraintChangeEvent cce = null;
+    fireConstraintEvent(nIdx, mcOld, mcNew, false);
+}
 
-            // Process the listeners last to first, notifying
-            // those that are interested in this event
-            for (int i = listeners.length - 2; i >= 0; i -= 2) {
-                if (listeners[i] == ConstraintChangeListener.class) {
-                    // Lazily create the event:
-                    if (cce == null) {
-                        cce = new ConstraintChangeEvent(
-                            this,
-                            nIdx,
-                            new CR(mcOld, nIdx),
-                            new CR(mcNew, nIdx));
-                    }
+	    private void fireConstraintEvent(
+        int nIdx,
+        Object mcOld,
+        Object mcNew,
+        boolean isDataChange) {
 
-                    ((ConstraintChangeListener) listeners[i + 1])
-                        .constraintNameChanged(cce);
-                }
+    Object[] listeners = theMEllListeners.getListenerList();
+    ConstraintChangeEvent cce = null;
+
+    for (int i = listeners.length - 2; i >= 0; i -= 2) {
+        if (listeners[i] == ConstraintChangeListener.class) {
+            if (cce == null) {
+                cce = new ConstraintChangeEvent(
+                        this,
+                        nIdx,
+                        new CR(mcOld, nIdx),
+                        new CR(mcNew, nIdx));
+            }
+
+            if (isDataChange) {
+                ((ConstraintChangeListener) listeners[i + 1]).constraintDataChanged(cce);
+            } else {
+                ((ConstraintChangeListener) listeners[i + 1]).constraintNameChanged(cce);
             }
         }
     }
+}
 
     /*
      * @see org.argouml.ui.targetmanager.TargetListener#targetAdded(


### PR DESCRIPTION
Refactored duplicated code between fireConstraintDataChanged() and fireConstraintNameChanged() in TabConstraints.java by creating a shared helper method fireConstraintEvent().

Created a private helper method fireConstraintEvent() to centralize shared logic for event handling. Updated fireConstraintDataChanged() and fireConstraintNameChanged() to call the helper method. Removed 24 lines of duplicated code, improving maintainability and reducing redundancy. Ensured that the isDataChange flag differentiates between constraintDataChanged() and constraintNameChanged() calls.