### PR TITLE
Fixed issue in ModuleLoader2

### DIFF
--- a/src/argouml-app/src/org/argouml/moduleloader/ModuleLoader2.java
+++ b/src/argouml-app/src/org/argouml/moduleloader/ModuleLoader2.java
@@ -642,9 +642,10 @@ public final class ModuleLoader2 {
             Enumeration<JarEntry> jarEntries = jarfile.entries();
             while (jarEntries.hasMoreElements()) {
                 JarEntry entry = jarEntries.nextElement();
-                loadedClass =
-                        loadedClass
-                                | processEntry(classloader, entry.getName());
+                String entryName = entry.getName();
+                if (!entryName.contains("..") && !entryName.startsWith("/") && !entryName.startsWith("\\")) {
+                    loadedClass = loadedClass | processEntry(classloader, entryName);
+                }
             }
         } else {
             Map<String, Attributes> entries = manifest.getEntries();


### PR DESCRIPTION
There is a path traversal vulnerability in the ModuleLoader2 class because it processed JAR entries without checking if their names were safe. Malicious entries could be used to access files outside the intended directory. This could allow attackers to load unexpected files or inject harmful content during module loading.Thus, fixed this issue in ModuleLoader2 